### PR TITLE
Add function to get catalog name from a spec class

### DIFF
--- a/orchestra/composers/base.py
+++ b/orchestra/composers/base.py
@@ -22,8 +22,8 @@ from orchestra.utils import plugin
 LOG = logging.getLogger(__name__)
 
 
-def get_composer(workflow_type):
-    return plugin.get_module('orchestra.composers', workflow_type)
+def get_composer(catalog):
+    return plugin.get_module('orchestra.composers', catalog)
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/orchestra/specs/base.py
+++ b/orchestra/specs/base.py
@@ -35,6 +35,8 @@ def isspec(value):
 
 
 class Spec(object):
+    _catalog = None
+
     _version = '1.0'
 
     _schema = {
@@ -138,6 +140,10 @@ class Spec(object):
             for name, value in six.iteritems(self.spec):
                 if re.match(pattern, name) and value:
                     setattr(self, name, spec_cls(value, member=True))
+
+    @classmethod
+    def get_catalog(cls):
+        return cls._catalog
 
     @classmethod
     def get_version(cls):

--- a/orchestra/specs/loader.py
+++ b/orchestra/specs/loader.py
@@ -21,5 +21,5 @@ def get_specs_path():
     return __name__[:__name__.rfind('.')]
 
 
-def get_spec_module(spec_type):
-    return importlib.import_module(get_specs_path() + '.' + spec_type)
+def get_spec_module(catalog):
+    return importlib.import_module(get_specs_path() + '.' + catalog)

--- a/orchestra/specs/mistral/v2/base.py
+++ b/orchestra/specs/mistral/v2/base.py
@@ -19,6 +19,8 @@ LOG = logging.getLogger(__name__)
 
 
 class Spec(base.Spec):
+    _catalog = 'mistral'
+
     _version = '2.0'
 
     _meta_schema = {
@@ -32,6 +34,8 @@ class Spec(base.Spec):
 
 
 class MappingSpec(base.MappingSpec):
+    _catalog = 'mistral'
+
     _version = '2.0'
 
     _meta_schema = {
@@ -45,6 +49,8 @@ class MappingSpec(base.MappingSpec):
 
 
 class SequenceSpec(base.SequenceSpec):
+    _catalog = 'mistral'
+
     _version = '2.0'
 
     _meta_schema = {

--- a/orchestra/specs/mock/workflows.py
+++ b/orchestra/specs/mock/workflows.py
@@ -19,4 +19,4 @@ LOG = logging.getLogger(__name__)
 
 
 class WorkflowSpec(base.Spec):
-    pass
+    _catalog = 'mock'

--- a/orchestra/tests/unit/specs/mistral/test_base_spec.py
+++ b/orchestra/tests/unit/specs/mistral/test_base_spec.py
@@ -37,6 +37,14 @@ class SpecTest(unittest.TestCase):
             mistral.WorkflowSpec
         )
 
+    def test_spec_catalog(self):
+        spec_module = loader.get_spec_module(self.spec_module_name)
+
+        self.assertEqual(
+            spec_module.WorkflowSpec.get_catalog(),
+            self.spec_module_name
+        )
+
     def test_spec_version(self):
         self.assertEqual('2.0', mistral_v2.VERSION)
         self.assertEqual('2.0', mistral.VERSION)

--- a/orchestra/tests/unit/specs/test_base_spec.py
+++ b/orchestra/tests/unit/specs/test_base_spec.py
@@ -114,6 +114,11 @@ class SpecTest(unittest.TestCase):
         super(SpecTest, self).setUp()
         self.maxDiff = None
 
+    def test_get_catalog(self):
+        self.assertIsNone(MockSpec.get_catalog())
+        self.assertIsNone(MockMappingSpec.get_catalog())
+        self.assertIsNone(MockSequenceSpec.get_catalog())
+
     def test_get_version(self):
         self.assertEqual('1.0', MockSpec.get_version())
 

--- a/orchestra/tests/unit/specs/test_spec_loader.py
+++ b/orchestra/tests/unit/specs/test_spec_loader.py
@@ -19,22 +19,13 @@ from orchestra.specs import loader
 class SpecLoaderTest(unittest.TestCase):
 
     def test_get_bad_module(self):
-        self.assertRaises(
-            ImportError,
-            loader.get_spec_module,
-            'foobar'
-        )
+        self.assertRaises(ImportError, loader.get_spec_module, 'foobar')
 
     def test_get_module(self):
-        self.assertEqual(
-            loader.get_spec_module('mock'),
-            mock
-        )
+        self.assertEqual(loader.get_spec_module('mock'), mock)
 
     def test_get_spec(self):
         spec_module = loader.get_spec_module('mock')
 
-        self.assertEqual(
-            spec_module.WorkflowSpec,
-            mock.WorkflowSpec
-        )
+        self.assertEqual(spec_module.WorkflowSpec.get_catalog(), 'mock')
+        self.assertEqual(spec_module.WorkflowSpec, mock.WorkflowSpec)


### PR DESCRIPTION
Add a helper function to retrieve the catalog name (i.e. mistral) from a spec class or instance.